### PR TITLE
Fixes the error outputted when an invalid file path is provided as input

### DIFF
--- a/Sources/stringray/Strings Table/StringsTableLoader.swift
+++ b/Sources/stringray/Strings Table/StringsTableLoader.swift
@@ -8,8 +8,15 @@
 import Foundation
 
 struct StringsTableLoader {
-	private enum Error: String, Swift.Error {
+	private enum Error: String, Swift.Error, LocalizedError {
 		case invalidURL
+		
+		var errorDescription: String? {
+			switch self {
+			case .invalidURL:
+				return "Invalid string resource URL provided."
+			}
+		}
 	}
 	
 	struct Options: OptionSet {


### PR DESCRIPTION
Since strings and stringsdict files are resource files, stringray expects the paths to these files to be resource urls and have a base component in the path.

After creating a test `.stringsdict` file and putting it in a plain folder, 
e.g. `stringray lint Tests/stringrayTests/Resources/TestStrings.stringsdict` this results in an awkward error message:
```
Linting: /repos/stringray/Tests/stringrayTests/Resources/TestStrings.stringsdict
The operation couldn’t be completed. (stringray.(unknown context at 0x10005595c).Error error 0.)
Program ended with exit code: 0
```

After this fix, the same error outputs: 
```
Linting: /repos/stringray/Tests/stringrayTests/Resources/TestStrings.stringsdict
Invalid string resource URL provided.
Program ended with exit code: 0
```